### PR TITLE
fix: correct condition for checkin flags OnPlayerConnect and condition when there is specators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 *.nupkg
 *.snupkg
 
+# Visual Studio files
+.vs

--- a/src/ReservedSlots (DU Support)/ReservedSlots.cs
+++ b/src/ReservedSlots (DU Support)/ReservedSlots.cs
@@ -148,7 +148,7 @@ public class ReservedSlots : BasePlugin, IPluginConfig<ReservedSlotsConfig>
         var player = @event.Userid;
         if (player != null && player.IsValid && player.SteamID.ToString().Length == 17)
         {
-            if (Config.adminFlagsAndRoles.Count == 0 && Config.adminFlagsAndRoles.Count == 0)
+            if (Config.adminFlagsAndRoles.Count == 0 && Config.reservedFlagsAndRoles.Count == 0)
                 return HookResult.Continue;
 
             int MaxPlayers = Server.MaxPlayers;
@@ -293,7 +293,7 @@ public class ReservedSlots : BasePlugin, IPluginConfig<ReservedSlotsConfig>
                 }
                 else
                 {
-                    SendConsoleMessage(text: $"[Reserved Slots] Selected player is NULL, no one is kicked!", ConsoleColor.Red);
+                    Logger.LogError($"[Reserved Slots] Selected player is NULL, no one is kicked!");
                 }
                 break;
         }
@@ -380,7 +380,7 @@ public class ReservedSlots : BasePlugin, IPluginConfig<ReservedSlotsConfig>
         if (Config.kickPlayersInSpectate)
         {
             if (playersList.Count(x => x.Team == CsTeam.None || x.Team == CsTeam.Spectator) > 0)
-                playersList.RemoveAll(x => x.Team != CsTeam.None || x.Team != CsTeam.Spectator);
+                playersList.RemoveAll(x => x.Team != CsTeam.None && x.Team != CsTeam.Spectator);
         }
 
         if (!playersList.Any())

--- a/src/ReservedSlots/ReservedSlots.cs
+++ b/src/ReservedSlots/ReservedSlots.cs
@@ -129,14 +129,14 @@ public class ReservedSlots : BasePlugin, IPluginConfig<ReservedSlotsConfig>
         var player = @event.Userid;
         if (player != null && player.IsValid && player.SteamID.ToString().Length == 17)
         {
-            if (Config.adminFlags.Count == 0 && Config.adminFlags.Count == 0)
+            if (Config.adminFlags.Count == 0 && Config.reservedFlags.Count == 0)
                 return HookResult.Continue;
 
             int MaxPlayers = Server.MaxPlayers;
             var playerReservedType = GetPlayersReservedType(player);
             if (playerReservedType == ReservedType.VIP || playerReservedType == ReservedType.Admin)
                 SetKickImmunity(player, playerReservedType);
-                
+
             switch (Config.reservedSlotsMethod)
             {
                 case 1:

--- a/src/ReservedSlots/ReservedSlots.cs
+++ b/src/ReservedSlots/ReservedSlots.cs
@@ -241,7 +241,7 @@ public class ReservedSlots : BasePlugin, IPluginConfig<ReservedSlotsConfig>
                 }
                 else
                 {
-                    SendConsoleMessage(text: $"[Reserved Slots] Selected player is NULL, no one is kicked!", ConsoleColor.Red);
+                    Logger.LogWarning($"[Reserved Slots] Selected player is NULL, no one is kicked!");
                 }
                 break;
         }
@@ -328,7 +328,7 @@ public class ReservedSlots : BasePlugin, IPluginConfig<ReservedSlotsConfig>
         if (Config.kickPlayersInSpectate)
         {
             if (playersList.Count(x => x.Team == CsTeam.None || x.Team == CsTeam.Spectator) > 0)
-                playersList.RemoveAll(x => x.Team != CsTeam.None || x.Team != CsTeam.Spectator);
+                playersList.RemoveAll(x => x.Team != CsTeam.None && x.Team != CsTeam.Spectator);
         }
 
         if (!playersList.Any())


### PR DESCRIPTION
Fixes two bugs / mistakes:

- OnPlayerConnect hook adminFlags count was checked twice instead of reservedFlags,
- kickPlayersInSpectate statement mistake